### PR TITLE
Make imports for ServiceCharm and DebuggerCharm similar to CharmBase

### DIFF
--- a/lib/hpctlib/ops/charm/__init__.py
+++ b/lib/hpctlib/ops/charm/__init__.py
@@ -1,9 +1,13 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
 #
 # hpctlib/ops/charm/__init__.py
-#
 
 """Support for operators.
 """
+
+from .debugger import DebuggerCharm
+from .service import ServiceCharm
 
 
 def set_base_charm(basecharm):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+cryptography==37.0.4
+setuptools==58.1.0


### PR DESCRIPTION
Tiny pull request, but something that I wanted to update was modifying the imports of `ServiceCharm` and `DebuggerCharm` to be more analogous to how `CharmBase` is imported from the `ops` library. Instead of:

```python3
from hpctlib.ops.charm.service import ServiceCharm
from hpctlib.ops.charm.debugger import DebuggerCharm as CharmBase
```

it is now:

```python3
from hpctlib.ops.charm import ServiceCharm
from hpctlib.ops.charm import DebuggerCharm as CharmBase
```

This makes the library (in my opinion) feel more similar to working with `ops` since `CharmBase` is imported as:

```python3
from ops.charm import CharmBase
```

**Side note:** I also added a `requirements.txt` file using pipreqs.